### PR TITLE
Handle java namespaces in field names

### DIFF
--- a/lib/about_page/configuration.rb
+++ b/lib/about_page/configuration.rb
@@ -70,6 +70,8 @@ module AboutPage
       self.nodes.collect do |key, profile| 
         if profile.class.validators.length > 0 
           health = profile.valid? ? 'ok' : 'error'
+          errors = []
+          profile.errors.messages.each_pair {|k,vals| vals.each {|v| errors << "#{k.to_s} #{v}"}}
           { 'component' => key.to_s, 'status' => health, 'errors' => profile.errors.to_a }
         else
           nil


### PR DESCRIPTION
Java namespaces in field names in the errors don't convert to strings nicely with errors.to_a: org.avalonmediasystem.AvalonWorkflowNotifier becomes something like Org Avalonmediasystem AvalonWorkflowNotifier.  There is probably a nicer way of doing this but I just manually convert the errors into an array.
